### PR TITLE
feature #7: persist settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+.vscode
+src/Semoda/Semoda/appsettings.json

--- a/src/Semoda/Semoda/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Semoda/Semoda/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Semoda.Models;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Semoda.Services;
+using Semoda.Services.Interfaces;
 using Semoda.ViewModels;
-using System.IO;
 
 namespace Semoda.Extensions
 {
@@ -17,22 +16,12 @@ namespace Semoda.Extensions
         /// <param name="collection">Collection, where the services should be added.</param>
         public static void AddAppServices(this IServiceCollection collection)
         {
-            //ViewModels
+            collection.AddSingleton<IConfigService, ConfigService>();
+
+            // ViewModels
             collection.AddSingleton<MainWindowViewModel>();
             collection.AddSingleton<DashboardPageViewModel>();
             collection.AddSingleton<SettingsPageViewModel>();
-
-            {
-                // Load settings from JSON and add for dependency injection
-                var configuration = new ConfigurationBuilder()
-                   .SetBasePath(Directory.GetCurrentDirectory())
-                   .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                   .Build();
-
-                var appSettings = new AppSettingsModel();
-                configuration.Bind(appSettings);
-                collection.AddSingleton(appSettings);
-            }
         }
     }
 }

--- a/src/Semoda/Semoda/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Semoda/Semoda/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Semoda.Models;
 using Semoda.ViewModels;
+using System.IO;
 
 namespace Semoda.Extensions
 {
@@ -18,6 +21,18 @@ namespace Semoda.Extensions
             collection.AddSingleton<MainWindowViewModel>();
             collection.AddSingleton<DashboardPageViewModel>();
             collection.AddSingleton<SettingsPageViewModel>();
+
+            {
+                // Load settings from JSON and add for dependency injection
+                var configuration = new ConfigurationBuilder()
+                   .SetBasePath(Directory.GetCurrentDirectory())
+                   .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                   .Build();
+
+                var appSettings = new AppSettingsModel();
+                configuration.Bind(appSettings);
+                collection.AddSingleton(appSettings);
+            }
         }
     }
 }

--- a/src/Semoda/Semoda/Models/AppSettingsModel.cs
+++ b/src/Semoda/Semoda/Models/AppSettingsModel.cs
@@ -1,61 +1,13 @@
-﻿using System.IO;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
-
-namespace Semoda.Models
+﻿namespace Semoda.Models
 {
     /// <summary>
     /// Model for the settings in the application.
-    /// All settings have default values - if no settings file is loaded, these are applied.
-    /// A settings file is first created when the settings are saved from the settings view.
-    /// Next time the app launches, those new settings will be loaded at startup.
     /// </summary>
-    public class AppSettingsModel : INotifyPropertyChanged
+    public class AppSettingsModel
     {
-        private string language = "en";
-
         /// <summary>
-        /// The current Language selected in the app.
+        /// Current app language
         /// </summary>
-        public string Language
-        {
-            get => language;
-            set
-            {
-                if(language != value)
-                {
-                    language = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Add event handlers here to be notified of changed settingss
-        /// </summary>
-        public event PropertyChangedEventHandler? PropertyChanged;
-
-        /// <summary>
-        /// Called when a property is changed, triggers event handlers
-        /// </summary>
-        /// <param name="propertyName"></param>
-        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
-        {
-               PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        /// <summary>
-        /// Save current settings to appsettings.json.
-        /// </summary>
-        public void Save()
-        {
-            var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText("appsettings.json", json);
-        }
+        public string Language {get; set;} = "en";
     }
 }

--- a/src/Semoda/Semoda/Models/AppSettingsModel.cs
+++ b/src/Semoda/Semoda/Models/AppSettingsModel.cs
@@ -1,0 +1,61 @@
+﻿using System.IO;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Semoda.Models
+{
+    /// <summary>
+    /// Model for the settings in the application.
+    /// All settings have default values - if no settings file is loaded, these are applied.
+    /// A settings file is first created when the settings are saved from the settings view.
+    /// Next time the app launches, those new settings will be loaded at startup.
+    /// </summary>
+    public class AppSettingsModel : INotifyPropertyChanged
+    {
+        private string language = "en";
+
+        /// <summary>
+        /// The current Language selected in the app.
+        /// </summary>
+        public string Language
+        {
+            get => language;
+            set
+            {
+                if(language != value)
+                {
+                    language = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add event handlers here to be notified of changed settingss
+        /// </summary>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>
+        /// Called when a property is changed, triggers event handlers
+        /// </summary>
+        /// <param name="propertyName"></param>
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+               PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        /// <summary>
+        /// Save current settings to appsettings.json.
+        /// </summary>
+        public void Save()
+        {
+            var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText("appsettings.json", json);
+        }
+    }
+}

--- a/src/Semoda/Semoda/Semoda.csproj
+++ b/src/Semoda/Semoda/Semoda.csproj
@@ -37,6 +37,9 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.11" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/Semoda/Semoda/Services/ConfigService.cs
+++ b/src/Semoda/Semoda/Services/ConfigService.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Semoda.Models;
+using Semoda.Services.Interfaces;
+
+namespace Semoda.Services {
+	/// <summary>
+	/// Implementation of the configuration service that saves settings to
+	/// and loads them from a json file.
+	/// </summary>
+    public class ConfigService : IConfigService
+    {
+		private event EventHandler<EventArgs>? SettingsChangedEvent = null;
+		private AppSettingsModel _appSettings;
+
+		/// <summary>
+		/// Loads the settings json file from the file system, first creating
+		/// it if it does not yet exist.
+		/// </summary>
+		public ConfigService()
+		{
+			if(!File.Exists("appsettings.json"))
+			{
+				File.WriteAllText("appsettings.json", JsonSerializer.Serialize(new AppSettingsModel(), new JsonSerializerOptions { WriteIndented = true }));
+			}
+
+			string fileContent = File.ReadAllText("appsettings.json");
+			_appSettings = JsonSerializer.Deserialize<AppSettingsModel>(fileContent) ?? new AppSettingsModel();
+		}
+
+		/// <inheritdoc/>
+        public AppSettingsModel GetAppSettings()
+        {
+			return _appSettings;
+        }
+
+		/// <summary>
+		/// Updates the application settings with the supplied version.
+		/// Saves the new settings to the file system and triggers an event
+		/// informing listeners of the change.
+		/// </summary>
+		/// <param name="newSettings">the new settings to save</param>
+		/// <returns>true if the settings were saved successfully, false otherwise</returns>
+		public bool Update(AppSettingsModel newSettings)
+		{
+            var json = JsonSerializer.Serialize(newSettings, new JsonSerializerOptions { WriteIndented = true });
+            try
+			{
+				File.WriteAllText("appsettings.json", json);
+			}
+			catch(Exception)
+			{
+				// TODO Log error
+				return false;
+			}
+
+			_appSettings = newSettings;
+
+			SettingsChangedEvent?.Invoke(this, new EventArgs());
+
+			return true;
+		}
+	
+		/// <inheritdoc/>
+		public bool Register(EventHandler<EventArgs> eventHandler)
+		{
+			SettingsChangedEvent += eventHandler;
+			return true;
+		}
+    }
+}

--- a/src/Semoda/Semoda/Services/ConfigService.cs
+++ b/src/Semoda/Semoda/Services/ConfigService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using Semoda.Models;
@@ -14,7 +15,7 @@ namespace Semoda.Services {
 		private event EventHandler<EventArgs>? SettingsChangedEvent = null;
 		private AppSettingsModel _appSettings;
 		private const string SETTINGS_FILE_NAME = "appsettings.json";
-		private const string SETTINGS_FOLDER_NAME = "Semoda";
+		private static readonly string SETTINGS_FOLDER_NAME = AppDomain.CurrentDomain.FriendlyName;
 
 		/// <summary>
 		/// Loads the settings json file from the file system, first creating

--- a/src/Semoda/Semoda/Services/ConfigService.cs
+++ b/src/Semoda/Semoda/Services/ConfigService.cs
@@ -13,6 +13,8 @@ namespace Semoda.Services {
     {
 		private event EventHandler<EventArgs>? SettingsChangedEvent = null;
 		private AppSettingsModel _appSettings;
+		private const string SettingsFileName = "appsettings.json";
+		private const string SettingsFolderName = "Semoda";
 
 		/// <summary>
 		/// Loads the settings json file from the file system, first creating
@@ -20,12 +22,17 @@ namespace Semoda.Services {
 		/// </summary>
 		public ConfigService()
 		{
-			if(!File.Exists("appsettings.json"))
+			string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+			string fileName = Path.Combine(folder, SettingsFolderName, SettingsFileName);
+
+			if(!File.Exists(fileName))
 			{
-				File.WriteAllText("appsettings.json", JsonSerializer.Serialize(new AppSettingsModel(), new JsonSerializerOptions { WriteIndented = true }));
+				FileInfo fileInfo = new FileInfo(fileName);
+				fileInfo.Directory?.Create();
+				File.WriteAllText(fileName, JsonSerializer.Serialize(new AppSettingsModel(), new JsonSerializerOptions { WriteIndented = true }));
 			}
 
-			string fileContent = File.ReadAllText("appsettings.json");
+			string fileContent = File.ReadAllText(fileName);
 			_appSettings = JsonSerializer.Deserialize<AppSettingsModel>(fileContent) ?? new AppSettingsModel();
 		}
 
@@ -47,7 +54,16 @@ namespace Semoda.Services {
             var json = JsonSerializer.Serialize(newSettings, new JsonSerializerOptions { WriteIndented = true });
             try
 			{
-				File.WriteAllText("appsettings.json", json);
+				string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+				string fileName = Path.Combine(folder, SettingsFolderName, SettingsFileName);
+
+				if(!File.Exists(fileName))
+				{
+					FileInfo fileInfo = new FileInfo(fileName);
+					fileInfo.Directory?.Create();
+				}
+
+				File.WriteAllText(fileName, json);
 			}
 			catch(Exception)
 			{

--- a/src/Semoda/Semoda/Services/ConfigService.cs
+++ b/src/Semoda/Semoda/Services/ConfigService.cs
@@ -13,8 +13,8 @@ namespace Semoda.Services {
     {
 		private event EventHandler<EventArgs>? SettingsChangedEvent = null;
 		private AppSettingsModel _appSettings;
-		private const string SettingsFileName = "appsettings.json";
-		private const string SettingsFolderName = "Semoda";
+		private const string SETTINGS_FILE_NAME = "appsettings.json";
+		private const string SETTINGS_FOLDER_NAME = "Semoda";
 
 		/// <summary>
 		/// Loads the settings json file from the file system, first creating
@@ -23,7 +23,7 @@ namespace Semoda.Services {
 		public ConfigService()
 		{
 			string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-			string fileName = Path.Combine(folder, SettingsFolderName, SettingsFileName);
+			string fileName = Path.Combine(folder, SETTINGS_FOLDER_NAME, SETTINGS_FILE_NAME);
 
 			if(!File.Exists(fileName))
 			{
@@ -55,7 +55,7 @@ namespace Semoda.Services {
             try
 			{
 				string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-				string fileName = Path.Combine(folder, SettingsFolderName, SettingsFileName);
+				string fileName = Path.Combine(folder, SETTINGS_FOLDER_NAME, SETTINGS_FILE_NAME);
 
 				if(!File.Exists(fileName))
 				{

--- a/src/Semoda/Semoda/Services/ConfigService.cs
+++ b/src/Semoda/Semoda/Services/ConfigService.cs
@@ -5,85 +5,86 @@ using System.Text.Json;
 using Semoda.Models;
 using Semoda.Services.Interfaces;
 
-namespace Semoda.Services {
-	/// <summary>
-	/// Implementation of the configuration service that saves settings to
-	/// and loads them from a json file.
-	/// </summary>
+namespace Semoda.Services
+{
+    /// <summary>
+    /// Implementation of the configuration service that saves settings to
+    /// and loads them from a json file.
+    /// </summary>
     public class ConfigService : IConfigService
     {
-		private event EventHandler<EventArgs>? SettingsChangedEvent = null;
-		private AppSettingsModel _appSettings;
-		private const string SETTINGS_FILE_NAME = "appsettings.json";
-		private static readonly string SETTINGS_FOLDER_NAME = AppDomain.CurrentDomain.FriendlyName;
+        private event EventHandler<EventArgs>? SettingsChangedEvent = null;
+        private AppSettingsModel _appSettings;
+        private const string SETTINGS_FILE_NAME = "appsettings.json";
+        private static readonly string SETTINGS_FOLDER_NAME = AppDomain.CurrentDomain.FriendlyName;
 
-		/// <summary>
-		/// Loads the settings json file from the file system, first creating
-		/// it if it does not yet exist.
-		/// </summary>
-		public ConfigService()
-		{
-			string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-			string fileName = Path.Combine(folder, SETTINGS_FOLDER_NAME, SETTINGS_FILE_NAME);
-
-			if(!File.Exists(fileName))
-			{
-				FileInfo fileInfo = new FileInfo(fileName);
-				fileInfo.Directory?.Create();
-				File.WriteAllText(fileName, JsonSerializer.Serialize(new AppSettingsModel(), new JsonSerializerOptions { WriteIndented = true }));
-			}
-
-			string fileContent = File.ReadAllText(fileName);
-			_appSettings = JsonSerializer.Deserialize<AppSettingsModel>(fileContent) ?? new AppSettingsModel();
-		}
-
-		/// <inheritdoc/>
-        public AppSettingsModel GetAppSettings()
+        /// <summary>
+        /// Loads the settings json file from the file system, first creating
+        /// it if it does not yet exist.
+        /// </summary>
+        public ConfigService()
         {
-			return _appSettings;
+            string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string fileName = Path.Combine(folder, SETTINGS_FOLDER_NAME, SETTINGS_FILE_NAME);
+
+            if (!File.Exists(fileName))
+            {
+                FileInfo fileInfo = new FileInfo(fileName);
+                fileInfo.Directory?.Create();
+                File.WriteAllText(fileName, JsonSerializer.Serialize(new AppSettingsModel(), new JsonSerializerOptions { WriteIndented = true }));
+            }
+
+            string fileContent = File.ReadAllText(fileName);
+            _appSettings = JsonSerializer.Deserialize<AppSettingsModel>(fileContent) ?? new AppSettingsModel();
         }
 
-		/// <summary>
-		/// Updates the application settings with the supplied version.
-		/// Saves the new settings to the file system and triggers an event
-		/// informing listeners of the change.
-		/// </summary>
-		/// <param name="newSettings">the new settings to save</param>
-		/// <returns>true if the settings were saved successfully, false otherwise</returns>
-		public bool Update(AppSettingsModel newSettings)
-		{
+        /// <inheritdoc/>
+        public AppSettingsModel GetAppSettings()
+        {
+            return _appSettings;
+        }
+
+        /// <summary>
+        /// Updates the application settings with the supplied version.
+        /// Saves the new settings to the file system and triggers an event
+        /// informing listeners of the change.
+        /// </summary>
+        /// <param name="newSettings">the new settings to save</param>
+        /// <returns>true if the settings were saved successfully, false otherwise</returns>
+        public bool Update(AppSettingsModel newSettings)
+        {
             var json = JsonSerializer.Serialize(newSettings, new JsonSerializerOptions { WriteIndented = true });
             try
-			{
-				string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-				string fileName = Path.Combine(folder, SETTINGS_FOLDER_NAME, SETTINGS_FILE_NAME);
+            {
+                string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                string fileName = Path.Combine(folder, SETTINGS_FOLDER_NAME, SETTINGS_FILE_NAME);
 
-				if(!File.Exists(fileName))
-				{
-					FileInfo fileInfo = new FileInfo(fileName);
-					fileInfo.Directory?.Create();
-				}
+                if (!File.Exists(fileName))
+                {
+                    FileInfo fileInfo = new FileInfo(fileName);
+                    fileInfo.Directory?.Create();
+                }
 
-				File.WriteAllText(fileName, json);
-			}
-			catch(Exception)
-			{
-				// TODO Log error
-				return false;
-			}
+                File.WriteAllText(fileName, json);
+            }
+            catch (Exception)
+            {
+                // TODO Log error
+                return false;
+            }
 
-			_appSettings = newSettings;
+            _appSettings = newSettings;
 
-			SettingsChangedEvent?.Invoke(this, new EventArgs());
+            SettingsChangedEvent?.Invoke(this, new EventArgs());
 
-			return true;
-		}
-	
-		/// <inheritdoc/>
-		public bool Register(EventHandler<EventArgs> eventHandler)
-		{
-			SettingsChangedEvent += eventHandler;
-			return true;
-		}
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public bool Register(EventHandler<EventArgs> eventHandler)
+        {
+            SettingsChangedEvent += eventHandler;
+            return true;
+        }
     }
 }

--- a/src/Semoda/Semoda/Services/Interfaces/IConfigService.cs
+++ b/src/Semoda/Semoda/Services/Interfaces/IConfigService.cs
@@ -1,0 +1,31 @@
+using System;
+using Semoda.Models;
+
+namespace Semoda.Services.Interfaces {
+	/// <summary>
+	/// Interface for Service that manages application configuration data
+	/// </summary>
+	public interface IConfigService {
+		/// <summary>
+		/// Gives access to the application settings
+		/// </summary>
+		/// <returns>a copy of the application settings</returns>
+		public AppSettingsModel GetAppSettings();
+
+		/// <summary>
+		/// Updates the application settings with the supplied version.
+		/// Persists the new settings and triggers an event
+		/// informing listeners of the change.
+		/// </summary>
+		/// <param name="newSettings">the new settings to save</param>
+		/// <returns>true if the settings were saved successfully, false otherwise</returns>
+		public bool Update(AppSettingsModel newSettings);
+
+		/// <summary>
+		/// Registers an event handler to be informed when any setting in the app is changed.
+		/// </summary>
+		/// <param name="eventHandler">the handler to register</param>
+		/// <returns>true if the handler was registered successfully, false otherwise</returns>
+		public bool Register(EventHandler<EventArgs> eventHandler);
+	}
+}

--- a/src/Semoda/Semoda/ViewModels/SettingsPageViewModel.cs
+++ b/src/Semoda/Semoda/ViewModels/SettingsPageViewModel.cs
@@ -1,18 +1,40 @@
-﻿using Semoda.Views.Pages;
+﻿using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
+using Semoda.Models;
+using Semoda.Services.Interfaces;
+using Semoda.Views.Pages;
 
 namespace Semoda.ViewModels
 {
     /// <summary>
     /// View model for the <see cref="SettingsPage"/>
     /// </summary>
-    public class SettingsPageViewModel : ViewModelBase
+    public partial class SettingsPageViewModel : ViewModelBase
     {
+        [ObservableProperty]
+        private AppSettingsModel _appSettingsModel;
+
+        private IConfigService _configService;
+
         /// <summary>
         /// Default constructor. <br/>
         /// Sets the <see cref="ViewModelBase.IsPage"/> to <see langword="true"/>
         /// </summary>
         public SettingsPageViewModel() : base(true)
         {
+            _configService = ServiceProvider.GetRequiredService<IConfigService>();
+            _configService.Register(HandleSettingsChanged);
+
+            AppSettingsModel = _configService.GetAppSettings();
+            
+            AppSettingsModel.Language = "de";
+            _configService.Update(AppSettingsModel);
+        }
+
+        private void HandleSettingsChanged(object? sender, EventArgs e)
+        {
+            AppSettingsModel = _configService.GetAppSettings();
         }
     }
 }

--- a/src/Semoda/Semoda/ViewModels/SettingsPageViewModel.cs
+++ b/src/Semoda/Semoda/ViewModels/SettingsPageViewModel.cs
@@ -27,9 +27,6 @@ namespace Semoda.ViewModels
             _configService.Register(HandleSettingsChanged);
 
             AppSettingsModel = _configService.GetAppSettings();
-            
-            AppSettingsModel.Language = "de";
-            _configService.Update(AppSettingsModel);
         }
 
         private void HandleSettingsChanged(object? sender, EventArgs e)


### PR DESCRIPTION
Here is a suggestion on how this may be implemented. It saves settings in a `appsettings.json` right next to the executable of the application, currently only a simple string for language since no settings have actually been implemented in the application.

If no settings file is found on startup, default settings can are used. These can then be changed and/or saved to a new `appsettings.json`.

This version of the feature uses [Microsoft.Extensions.Configuration](https://www.nuget.org/packages/Microsoft.Extensions.Configuration) to load the configuration file. This is slightly overkilly for the simple json file case, but leaves room to later load from environment variables or other (custom) sources.

The Microsoft package does not offer any functionality for saving settings, so they are simply json-serialized and written to the local file system using standard C# functions.

The `AppSettingsModel` offers a `PropertyChangedEventHandler` that can be used to react to settings changes.

The model can be dependency injected, such as:

```
public DashboardPageViewModel(AppSettingsModel appSettings) : base(true)
{
    Debug.WriteLine("Current app language: " + appSettings.Language);
}
```