### PR TITLE
Feature/14 service to get performance data

### DIFF
--- a/src/Semoda/Semoda/Extensions/PerformanceDataTypeExtensions.cs
+++ b/src/Semoda/Semoda/Extensions/PerformanceDataTypeExtensions.cs
@@ -1,31 +1,44 @@
 ﻿using Semoda.Models;
+using Semoda.PerformanceDataCollector;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Semoda.Extensions
 {
-#pragma warning disable CA1416 // Validate platform compatibility
-
     /// <summary>
     /// Extensions for the <see cref="PerformanceDataType"/>
     /// </summary>
     public static class PerformanceDataTypeExtensions
     {
         /// <summary>
-        /// Convert the data type to a <see cref="PerformanceCounter"/>
+        /// Convert the data type to a <see cref="IPerformanceDataCollector"/>
         /// </summary>
         /// <param name="dataType">Type to convert</param>
-        /// <returns>The corresponding <see cref="PerformanceCounter"/> of the dataType.
-        /// <see langword="null"/> if there is no linked <see cref="PerformanceCounter"/>.</returns>
-        public static PerformanceCounter? ToPerformanceCounter(this PerformanceDataType dataType)
+        /// <returns>The corresponding <see cref="IPerformanceDataCollector"/> of the dataType.
+        /// <see langword="null"/> if there is no linked <see cref="IPerformanceDataCollector"/>.</returns>
+        public static IPerformanceDataCollector? ToPerformanceDataCollector(this PerformanceDataType dataType)
         {
             switch (dataType)
             {
                 case PerformanceDataType.TotalCPUUtilization:
-                    return new PerformanceCounter("Processor Information", "% Processor Utility", "_Total");
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        return new PerformanceDataCollectorWindows(new PerformanceCounter("Processor Information", "% Processor Utility", "_Total"));
+                    break;
+
+                case PerformanceDataType.TotalRAMAvailable:
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        return new PerformanceDataCollectorWindows(new PerformanceCounter("Memory", "Available MBytes"));
+                    break;
+
+                case PerformanceDataType.CPUTemperature:
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        return new PerformanceDataCollectorWindows(new PerformanceCounter("Thermal Zone Information", "Temperature", "_TZ.THRM"));
+                    break;
 
                 default:
                     return null;
             }
+            return null;
         }
 
         /// <summary>
@@ -40,11 +53,15 @@ namespace Semoda.Extensions
                 case PerformanceDataType.TotalCPUUtilization:
                     return "%";
 
+                case PerformanceDataType.TotalRAMAvailable:
+                    return "MB";
+
+                case PerformanceDataType.CPUTemperature:
+                    return "°C";
+
                 default:
                     return "";
             }
         }
     }
-
-#pragma warning restore CA1416
 }

--- a/src/Semoda/Semoda/Extensions/PerformanceDataTypeExtensions.cs
+++ b/src/Semoda/Semoda/Extensions/PerformanceDataTypeExtensions.cs
@@ -25,9 +25,6 @@ namespace Semoda.Extensions
                 case PerformanceDataType.TotalRAMAvailable:
                     return "MB";
 
-                case PerformanceDataType.CPUTemperature:
-                    return "°C";
-
                 default:
                     return "";
             }
@@ -52,8 +49,6 @@ namespace Semoda.Extensions
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                         return new PerformanceDataCollectorWindows(new PerformanceCounter("Memory", "Available MBytes"));
                     break;
-
-                case PerformanceDataType.CPUTemperature:
 
                 default:
                     return null;

--- a/src/Semoda/Semoda/Extensions/PerformanceDataTypeExtensions.cs
+++ b/src/Semoda/Semoda/Extensions/PerformanceDataTypeExtensions.cs
@@ -11,37 +11,6 @@ namespace Semoda.Extensions
     public static class PerformanceDataTypeExtensions
     {
         /// <summary>
-        /// Convert the data type to a <see cref="IPerformanceDataCollector"/>
-        /// </summary>
-        /// <param name="dataType">Type to convert</param>
-        /// <returns>The corresponding <see cref="IPerformanceDataCollector"/> of the dataType.
-        /// <see langword="null"/> if there is no linked <see cref="IPerformanceDataCollector"/>.</returns>
-        public static IPerformanceDataCollector? ToPerformanceDataCollector(this PerformanceDataType dataType)
-        {
-            switch (dataType)
-            {
-                case PerformanceDataType.TotalCPUUtilization:
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                        return new PerformanceDataCollectorWindows(new PerformanceCounter("Processor Information", "% Processor Utility", "_Total"));
-                    break;
-
-                case PerformanceDataType.TotalRAMAvailable:
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                        return new PerformanceDataCollectorWindows(new PerformanceCounter("Memory", "Available MBytes"));
-                    break;
-
-                case PerformanceDataType.CPUTemperature:
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                        return new PerformanceDataCollectorWindows(new PerformanceCounter("Thermal Zone Information", "Temperature", "_TZ.THRM"));
-                    break;
-
-                default:
-                    return null;
-            }
-            return null;
-        }
-
-        /// <summary>
         /// Get the default unit for the <see cref="PerformanceDataType"/>
         /// </summary>
         /// <param name="dataType">Type of which the unit should be gathered.</param>
@@ -62,6 +31,34 @@ namespace Semoda.Extensions
                 default:
                     return "";
             }
+        }
+
+        /// <summary>
+        /// Convert the data type to a <see cref="IPerformanceDataCollector"/>
+        /// </summary>
+        /// <param name="dataType">Type to convert</param>
+        /// <returns>The corresponding <see cref="IPerformanceDataCollector"/> of the dataType.
+        /// <see langword="null"/> if there is no linked <see cref="IPerformanceDataCollector"/>.</returns>
+        public static IPerformanceDataCollector? ToPerformanceDataCollector(this PerformanceDataType dataType)
+        {
+            switch (dataType)
+            {
+                case PerformanceDataType.TotalCPUUtilization:
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        return new PerformanceDataCollectorWindows(new PerformanceCounter("Processor Information", "% Processor Utility", "_Total"));
+                    break;
+
+                case PerformanceDataType.TotalRAMAvailable:
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        return new PerformanceDataCollectorWindows(new PerformanceCounter("Memory", "Available MBytes"));
+                    break;
+
+                case PerformanceDataType.CPUTemperature:
+
+                default:
+                    return null;
+            }
+            return null;
         }
     }
 }

--- a/src/Semoda/Semoda/Extensions/PerformanceDataTypeExtensions.cs
+++ b/src/Semoda/Semoda/Extensions/PerformanceDataTypeExtensions.cs
@@ -1,0 +1,50 @@
+﻿using Semoda.Models;
+using System.Diagnostics;
+
+namespace Semoda.Extensions
+{
+#pragma warning disable CA1416 // Validate platform compatibility
+
+    /// <summary>
+    /// Extensions for the <see cref="PerformanceDataType"/>
+    /// </summary>
+    public static class PerformanceDataTypeExtensions
+    {
+        /// <summary>
+        /// Convert the data type to a <see cref="PerformanceCounter"/>
+        /// </summary>
+        /// <param name="dataType">Type to convert</param>
+        /// <returns>The corresponding <see cref="PerformanceCounter"/> of the dataType.
+        /// <see langword="null"/> if there is no linked <see cref="PerformanceCounter"/>.</returns>
+        public static PerformanceCounter? ToPerformanceCounter(this PerformanceDataType dataType)
+        {
+            switch (dataType)
+            {
+                case PerformanceDataType.TotalCPUUtilization:
+                    return new PerformanceCounter("Processor Information", "% Processor Utility", "_Total");
+
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// Get the default unit for the <see cref="PerformanceDataType"/>
+        /// </summary>
+        /// <param name="dataType">Type of which the unit should be gathered.</param>
+        /// <returns>The default unit of the dataType. An empty string if there is no default unit.</returns>
+        public static string GetDefaultUnit(this PerformanceDataType dataType)
+        {
+            switch (dataType)
+            {
+                case PerformanceDataType.TotalCPUUtilization:
+                    return "%";
+
+                default:
+                    return "";
+            }
+        }
+    }
+
+#pragma warning restore CA1416
+}

--- a/src/Semoda/Semoda/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Semoda/Semoda/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Semoda.Services;
+using Semoda.Services.Interfaces;
 using Semoda.ViewModels;
 
 namespace Semoda.Extensions
@@ -14,6 +16,9 @@ namespace Semoda.Extensions
         /// <param name="collection">Collection, where the services should be added.</param>
         public static void AddAppServices(this IServiceCollection collection)
         {
+            //Services
+            collection.AddSingleton<IPerformanceDataService, PerformanceDataService>();
+
             //ViewModels
             collection.AddSingleton<MainWindowViewModel>();
             collection.AddSingleton<DashboardPageViewModel>();

--- a/src/Semoda/Semoda/Models/Events/PerformanceDataEventArgs.cs
+++ b/src/Semoda/Semoda/Models/Events/PerformanceDataEventArgs.cs
@@ -16,7 +16,7 @@ namespace Semoda.Models.Events
         /// <summary>
         /// Value of the performance data
         /// </summary>
-        public float Value { get; init; }
+        public float? Value { get; init; }
 
         /// <summary>
         /// Type of the performance data

--- a/src/Semoda/Semoda/Models/Events/PerformanceDataEventArgs.cs
+++ b/src/Semoda/Semoda/Models/Events/PerformanceDataEventArgs.cs
@@ -16,6 +16,11 @@ namespace Semoda.Models.Events
         /// <summary>
         /// Value of the performance data
         /// </summary>
-        public double Value { get; init; }
+        public float Value { get; init; }
+
+        /// <summary>
+        /// Type of the performance data
+        /// </summary>
+        public PerformanceDataType PerformanceDataType { get; init; }
     }
 }

--- a/src/Semoda/Semoda/Models/Events/PerformanceDataEventArgs.cs
+++ b/src/Semoda/Semoda/Models/Events/PerformanceDataEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using Semoda.Services.Interfaces;
+using System;
+
+namespace Semoda.Models.Events
+{
+    /// <summary>
+    /// EventArgs for new peformance data. This event is fired by the <see cref="IPerformanceDataService"/>
+    /// </summary>
+    public class PerformanceDataEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Unit of the performance data
+        /// </summary>
+        public string Unit { get; init; } = "";
+
+        /// <summary>
+        /// Value of the performance data
+        /// </summary>
+        public double Value { get; init; }
+    }
+}

--- a/src/Semoda/Semoda/Models/PerformanceDataType.cs
+++ b/src/Semoda/Semoda/Models/PerformanceDataType.cs
@@ -10,5 +10,14 @@
         /// </summary>
         TotalCPUUtilization,
 
+        /// <summary>
+        /// Temperature of the cpu
+        /// </summary>
+        CPUTemperature,
+
+        /// <summary>
+        /// Total available memory
+        /// </summary>
+        TotalRAMAvailable,
     }
 }

--- a/src/Semoda/Semoda/Models/PerformanceDataType.cs
+++ b/src/Semoda/Semoda/Models/PerformanceDataType.cs
@@ -1,0 +1,14 @@
+﻿namespace Semoda.Models
+{
+    /// <summary>
+    /// Enum to hold the difference type of perfomance data
+    /// </summary>
+    public enum PerformanceDataType
+    {
+        /// <summary>
+        /// Total percentage of cpu utilization
+        /// </summary>
+        TotalCPUUtilization,
+
+    }
+}

--- a/src/Semoda/Semoda/Models/PerformanceDataType.cs
+++ b/src/Semoda/Semoda/Models/PerformanceDataType.cs
@@ -11,13 +11,8 @@
         TotalCPUUtilization,
 
         /// <summary>
-        /// Temperature of the cpu
-        /// </summary>
-        CPUTemperature,
-
-        /// <summary>
         /// Total available memory
         /// </summary>
-        TotalRAMAvailable,
+        TotalRAMAvailable
     }
 }

--- a/src/Semoda/Semoda/PerformanceDataCollector/IPerformanceDataCollector.cs
+++ b/src/Semoda/Semoda/PerformanceDataCollector/IPerformanceDataCollector.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace Semoda.PerformanceDataCollector
+{
+    /// <summary>
+    /// Interface for performance data collector.
+    /// </summary>
+    public interface IPerformanceDataCollector
+    {
+        /// <summary>
+        /// Collect a new value.
+        /// </summary>
+        /// <returns>The current value of the performance data. <see langword="null"/> if there is no data</returns>
+        Task<float?> CollectAsync();
+    }
+}

--- a/src/Semoda/Semoda/PerformanceDataCollector/PerformanceDataCollectorWindows.cs
+++ b/src/Semoda/Semoda/PerformanceDataCollector/PerformanceDataCollectorWindows.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Semoda.PerformanceDataCollector
+{
+    /// <summary>
+    /// Concrete implementation of the <see cref="IPerformanceDataCollector"/> for windows.
+    /// </summary>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public class PerformanceDataCollectorWindows : IPerformanceDataCollector
+    {
+        private PerformanceCounter _performanceCounter;
+
+        /// <summary>
+        /// Default constructor. Sets the <see cref="PerformanceCounter"/>
+        /// </summary>
+        /// <param name="performanceCounter">The underlying performance counter</param>
+        public PerformanceDataCollectorWindows(PerformanceCounter performanceCounter)
+        {
+            _performanceCounter = performanceCounter;
+        }
+
+        /// <inheritdoc/>
+        public async Task<float?> CollectAsync()
+        {
+            return await Task.FromResult(_performanceCounter.NextValue());
+        }
+    }
+}

--- a/src/Semoda/Semoda/Semoda.csproj
+++ b/src/Semoda/Semoda/Semoda.csproj
@@ -7,6 +7,11 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,6 +43,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Semoda/Semoda/Semoda.csproj
+++ b/src/Semoda/Semoda/Semoda.csproj
@@ -14,7 +14,6 @@
     <AvaloniaResource Remove="Assets\Languages\Resources.de-DE.resx" />
     <AvaloniaResource Remove="Assets\Languages\Resources.Designer.cs" />
     <AvaloniaResource Remove="Assets\Languages\Resources.resx" />
-    <Folder Include="Services\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,6 +37,7 @@
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.11" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Semoda/Semoda/Services/Interfaces/IPerformanceDataService.cs
+++ b/src/Semoda/Semoda/Services/Interfaces/IPerformanceDataService.cs
@@ -1,0 +1,39 @@
+﻿using Semoda.Models.Events;
+using System;
+using System.Threading.Tasks;
+
+namespace Semoda.Services.Interfaces
+{
+    /// <summary>
+    /// Interface to define a service, which collects and publishes performance data.
+    /// </summary>
+    public interface IPerformanceDataService
+    {
+        /// <summary>
+        /// Deregister at the service, to get norified about new events.
+        /// </summary>
+        /// <param name="eventHandler">Registered handler for the <see cref="PerformanceDataEventArgs"/></param>
+        /// <returns><see langword="true"/> if the handler could be deregistered. <see langword="false"/> otherwise.</returns>
+        Task<bool> DeregisterAsync(Action<object, PerformanceDataEventArgs> eventHandler);
+
+        /// <summary>
+        /// Register at the service, to get norified about new events.
+        /// </summary>
+        /// <param name="eventHandler">Handler for the <see cref="PerformanceDataEventArgs"/></param>
+        /// <returns><see langword="true"/> if the handler could be registered. <see langword="false"/> otherwise.</returns>
+        Task<bool> RegisterAsync(EventHandler<PerformanceDataEventArgs> eventHandler);
+        //Task<bool> RegisterAsync(Action<object, PerformanceDataEventArgs> eventHandler);
+
+        /// <summary>
+        /// Start the collection of performance data.
+        /// </summary>
+        /// <returns></returns>
+        Task StartAsync();
+
+        /// <summary>
+        /// Stop the collection of performance data.
+        /// </summary>
+        /// <returns></returns>
+        Task StopAsync();
+    }
+}

--- a/src/Semoda/Semoda/Services/Interfaces/IPerformanceDataService.cs
+++ b/src/Semoda/Semoda/Services/Interfaces/IPerformanceDataService.cs
@@ -1,4 +1,5 @@
-﻿using Semoda.Models.Events;
+﻿using Semoda.Models;
+using Semoda.Models.Events;
 using System;
 using System.Threading.Tasks;
 
@@ -20,9 +21,9 @@ namespace Semoda.Services.Interfaces
         /// Register at the service, to get norified about new events.
         /// </summary>
         /// <param name="eventHandler">Handler for the <see cref="PerformanceDataEventArgs"/></param>
+        /// <param name="dataType"></param>
         /// <returns><see langword="true"/> if the handler could be registered. <see langword="false"/> otherwise.</returns>
-        Task<bool> RegisterAsync(EventHandler<PerformanceDataEventArgs> eventHandler);
-        //Task<bool> RegisterAsync(Action<object, PerformanceDataEventArgs> eventHandler);
+        Task<bool> RegisterAsync(EventHandler<PerformanceDataEventArgs> eventHandler, PerformanceDataType dataType);
 
         /// <summary>
         /// Start the collection of performance data.

--- a/src/Semoda/Semoda/Services/Interfaces/IPerformanceDataService.cs
+++ b/src/Semoda/Semoda/Services/Interfaces/IPerformanceDataService.cs
@@ -11,14 +11,14 @@ namespace Semoda.Services.Interfaces
     public interface IPerformanceDataService
     {
         /// <summary>
-        /// Deregister at the service, to get norified about new events.
+        /// Deregister at the service, to no longet get notified about new events.
         /// </summary>
         /// <param name="eventHandler">Registered handler for the <see cref="PerformanceDataEventArgs"/></param>
         /// <returns><see langword="true"/> if the handler could be deregistered. <see langword="false"/> otherwise.</returns>
         Task<bool> DeregisterAsync(Action<object, PerformanceDataEventArgs> eventHandler);
 
         /// <summary>
-        /// Register at the service, to get norified about new events.
+        /// Register at the service, to get notified about new events.
         /// </summary>
         /// <param name="eventHandler">Handler for the <see cref="PerformanceDataEventArgs"/></param>
         /// <param name="dataType"></param>

--- a/src/Semoda/Semoda/Services/PerformanceDataService.cs
+++ b/src/Semoda/Semoda/Services/PerformanceDataService.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Semoda.Services
 {
-#pragma warning disable CA1416 // Validate platform compatibility
+//#pragma warning disable CA1416 // Validate platform compatibility
 
     /// <summary>
     /// Concrete implementation of the <see cref="IPerformanceDataService"/>
@@ -83,5 +83,5 @@ namespace Semoda.Services
         }
     }
 
-#pragma warning restore CA1416
+//#pragma warning restore CA1416
 }

--- a/src/Semoda/Semoda/Services/PerformanceDataService.cs
+++ b/src/Semoda/Semoda/Services/PerformanceDataService.cs
@@ -1,0 +1,69 @@
+﻿using Semoda.Models.Events;
+using Semoda.Services.Interfaces;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Semoda.Services
+{
+#pragma warning disable CA1416 // Validate platform compatibility
+
+    /// <summary>
+    /// Concrete implementation of the <see cref="IPerformanceDataService"/>
+    /// </summary>
+    public class PerformanceDataService : IPerformanceDataService
+    {
+        private CancellationTokenSource _cts;
+
+        /// <summary>
+        /// Stanard constructor.
+        /// </summary>
+        public PerformanceDataService()
+        {
+            _cts = new CancellationTokenSource();
+        }
+
+        private event EventHandler<PerformanceDataEventArgs>? NewPerformanceDataEvent = null;
+
+        /// <inheritdoc/>
+        public Task<bool> DeregisterAsync(Action<object, PerformanceDataEventArgs> eventHandler)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> RegisterAsync(EventHandler<PerformanceDataEventArgs> eventHandler)
+        {
+            NewPerformanceDataEvent += eventHandler;
+            return Task.FromResult(true);
+        }
+
+        /// <inheritdoc/>
+        public async Task StartAsync()
+        {
+            _ = Task.Run(async () =>
+            {
+                PerformanceCounter cpuPerformance = new PerformanceCounter("Processor", "% Processor Time", "_Total");
+
+                while (!_cts.IsCancellationRequested)
+                {
+                    await Task.Delay(1000);
+                    NewPerformanceDataEvent?.Invoke(this, new PerformanceDataEventArgs()
+                    {
+                        Unit = "%",
+                        Value = cpuPerformance.NextValue()
+                    });
+                }
+            }, _cts.Token);
+        }
+
+        /// <inheritdoc/>
+        public async Task StopAsync()
+        {
+            await _cts.CancelAsync();
+        }
+    }
+
+#pragma warning restore CA1416 // Validate platform compatibility
+}

--- a/src/Semoda/Semoda/Services/PerformanceDataService.cs
+++ b/src/Semoda/Semoda/Services/PerformanceDataService.cs
@@ -17,8 +17,10 @@ namespace Semoda.Services
     /// </summary>
     public class PerformanceDataService : IPerformanceDataService
     {
+        private static readonly int DEFAULT_POLLING_DELAY_MS = 1000;
         private CancellationTokenSource _cts;
         private ConcurrentDictionary<PerformanceDataType, (int count, IPerformanceDataCollector performanceDataCollector)> _performanceDataCollectors;
+        private int _pollingDelayMS = DEFAULT_POLLING_DELAY_MS;
 
         /// <summary>
         /// Stanard constructor.
@@ -56,7 +58,7 @@ namespace Semoda.Services
             {
                 while (!_cts.IsCancellationRequested)
                 {
-                    await Task.Delay(1000);
+                    await Task.Delay(_pollingDelayMS);
                     List<PerformanceDataType> keys = _performanceDataCollectors.Keys.ToList();
                     foreach (var key in keys)
                     {

--- a/src/Semoda/Semoda/Utils/SystemInfoUtil.cs
+++ b/src/Semoda/Semoda/Utils/SystemInfoUtil.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 namespace Semoda.Utils
 {
     /// <summary>
-    /// Util class to get informations about the system.
+    /// Util class to get information about the system.
     /// </summary>
     public class SystemInfoUtil
     {

--- a/src/Semoda/Semoda/Utils/SystemInfoUtil.cs
+++ b/src/Semoda/Semoda/Utils/SystemInfoUtil.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using System.Management;
+using System.Runtime.InteropServices;
+
+namespace Semoda.Utils
+{
+    /// <summary>
+    /// Util class to get informations about the system.
+    /// </summary>
+    public class SystemInfoUtil
+    {
+        /// <summary>
+        /// Gets the total available memory of the system in MB
+        /// </summary>
+        /// <returns>The total available memory of the system in MB</returns>
+        public static ulong GetTotalPhysicalMemoryMB()
+        {
+            ulong totalPhysicalMemory = 0;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                ManagementObjectSearcher searcher = new ManagementObjectSearcher("SELECT TotalPhysicalMemory FROM Win32_ComputerSystem");
+                foreach (ManagementObject queryObj in searcher.Get())
+                {
+                    totalPhysicalMemory += Convert.ToUInt64(queryObj["TotalPhysicalMemory"]);
+                }
+
+                return totalPhysicalMemory / (1024 * 1024);
+            }
+            else
+            {
+                using (StreamReader reader = new StreamReader("/proc/meminfo"))
+                {
+                    string? line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        if (line.StartsWith("MemTotal:"))
+                        {
+                            string[] parts = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                            if (parts.Length == 3 && parts[2] == "kB")
+                            {
+                                totalPhysicalMemory = Convert.ToUInt64(parts[1]) / 1024; // Convert from kB to mbytes
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                return totalPhysicalMemory;
+            }
+        }
+    }
+}

--- a/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
+++ b/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
@@ -20,23 +20,25 @@ namespace Semoda.ViewModels
         {
             IPerformanceDataService dataService = ServiceProvider.GetRequiredService<IPerformanceDataService>();
 
-            _ = dataService.RegisterAsync(HandleCPUUtilization, Models.PerformanceDataType.TotalCPUUtilization).ContinueWith((t) =>
+            _ = dataService.RegisterAsync(HandleNewData, Models.PerformanceDataType.TotalCPUUtilization).ContinueWith((t) =>
             {
                 _ = dataService.StartAsync();
-                _ = dataService.RegisterAsync(HandleRAMAvailable, Models.PerformanceDataType.TotalRAMAvailable);
+                _ = dataService.RegisterAsync(HandleNewData, Models.PerformanceDataType.TotalRAMAvailable);
             });
         }
 
-        private void HandleCPUUtilization(object? sender, PerformanceDataEventArgs args)
+        private void HandleNewData(object? sender, PerformanceDataEventArgs args)
         {
-            if (args.PerformanceDataType == Models.PerformanceDataType.TotalCPUUtilization)
-                Debug.WriteLine($"{args.PerformanceDataType}: {args.Value} {args.Unit}");
-        }
+            switch (args.PerformanceDataType)
+            {
+                case Models.PerformanceDataType.TotalRAMAvailable:
+                    Debug.WriteLine($"{args.PerformanceDataType}: {args.Value} {args.Unit} / {SystemInfoUtil.GetTotalPhysicalMemoryMB()} {args.Unit}");
+                    break;
 
-        private void HandleRAMAvailable(object? sender, PerformanceDataEventArgs args)
-        {
-            if (args.PerformanceDataType == Models.PerformanceDataType.TotalRAMAvailable)
-                Debug.WriteLine($"{args.PerformanceDataType}: {args.Value} {args.Unit} / {SystemInfoUtil.GetTotalPhysicalMemoryMB()} {args.Unit}");
+                default:
+                    Debug.WriteLine($"{args.PerformanceDataType}: {args.Value} {args.Unit}");
+                    break;
+            }
         }
     }
 }

--- a/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
+++ b/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
@@ -1,4 +1,9 @@
-﻿using Semoda.Views.Pages;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Semoda.Models.Events;
+using Semoda.Services.Interfaces;
+using Semoda.Views.Pages;
+using System;
+using System.Diagnostics;
 
 namespace Semoda.ViewModels
 {
@@ -13,6 +18,18 @@ namespace Semoda.ViewModels
         /// </summary>
         public DashboardPageViewModel() : base(true)
         {
+
+            IPerformanceDataService dataService = ServiceProvider.GetRequiredService<IPerformanceDataService>();
+
+            _ = dataService.RegisterAsync(HandleNewPerformanceData).ContinueWith((t) =>
+            {
+                _ = dataService.StartAsync();
+            });
+        }
+
+        private async void HandleNewPerformanceData(object sender, PerformanceDataEventArgs args)
+        {
+            Debug.WriteLine($"{args.Value} {args.Unit}");
         }
     }
 }

--- a/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
+++ b/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
@@ -24,14 +24,7 @@ namespace Semoda.ViewModels
             {
                 _ = dataService.StartAsync();
                 _ = dataService.RegisterAsync(HandleRAMAvailable, Models.PerformanceDataType.TotalRAMAvailable);
-                _ = dataService.RegisterAsync(HandleCPUTemp, Models.PerformanceDataType.CPUTemperature);
             });
-        }
-
-        private void HandleCPUTemp(object? sender, PerformanceDataEventArgs args)
-        {
-            if (args.PerformanceDataType == Models.PerformanceDataType.CPUTemperature)
-                Debug.WriteLine($"{args.PerformanceDataType}: {args.Value} {args.Unit}");
         }
 
         private void HandleCPUUtilization(object? sender, PerformanceDataEventArgs args)

--- a/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
+++ b/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Semoda.Models.Events;
 using Semoda.Services.Interfaces;
+using Semoda.Utils;
 using Semoda.Views.Pages;
-using System;
 using System.Diagnostics;
 
 namespace Semoda.ViewModels
@@ -18,18 +18,32 @@ namespace Semoda.ViewModels
         /// </summary>
         public DashboardPageViewModel() : base(true)
         {
-
             IPerformanceDataService dataService = ServiceProvider.GetRequiredService<IPerformanceDataService>();
 
-            _ = dataService.RegisterAsync(HandleNewPerformanceData, Models.PerformanceDataType.TotalCPUUtilization).ContinueWith((t) =>
+            _ = dataService.RegisterAsync(HandleCPUUtilization, Models.PerformanceDataType.TotalCPUUtilization).ContinueWith((t) =>
             {
                 _ = dataService.StartAsync();
+                _ = dataService.RegisterAsync(HandleRAMAvailable, Models.PerformanceDataType.TotalRAMAvailable);
+                _ = dataService.RegisterAsync(HandleCPUTemp, Models.PerformanceDataType.CPUTemperature);
             });
         }
 
-        private void HandleNewPerformanceData(object? sender, PerformanceDataEventArgs args)
+        private void HandleCPUTemp(object? sender, PerformanceDataEventArgs args)
         {
-            Debug.WriteLine($"{args.Value} {args.Unit}");
+            if (args.PerformanceDataType == Models.PerformanceDataType.CPUTemperature)
+                Debug.WriteLine($"{args.PerformanceDataType}: {args.Value} {args.Unit}");
+        }
+
+        private void HandleCPUUtilization(object? sender, PerformanceDataEventArgs args)
+        {
+            if (args.PerformanceDataType == Models.PerformanceDataType.TotalCPUUtilization)
+                Debug.WriteLine($"{args.PerformanceDataType}: {args.Value} {args.Unit}");
+        }
+
+        private void HandleRAMAvailable(object? sender, PerformanceDataEventArgs args)
+        {
+            if (args.PerformanceDataType == Models.PerformanceDataType.TotalRAMAvailable)
+                Debug.WriteLine($"{args.PerformanceDataType}: {args.Value} {args.Unit} / {SystemInfoUtil.GetTotalPhysicalMemoryMB()} {args.Unit}");
         }
     }
 }

--- a/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
+++ b/src/Semoda/Semoda/ViewModels/DashboardPageViewModel.cs
@@ -21,13 +21,13 @@ namespace Semoda.ViewModels
 
             IPerformanceDataService dataService = ServiceProvider.GetRequiredService<IPerformanceDataService>();
 
-            _ = dataService.RegisterAsync(HandleNewPerformanceData).ContinueWith((t) =>
+            _ = dataService.RegisterAsync(HandleNewPerformanceData, Models.PerformanceDataType.TotalCPUUtilization).ContinueWith((t) =>
             {
                 _ = dataService.StartAsync();
             });
         }
 
-        private async void HandleNewPerformanceData(object sender, PerformanceDataEventArgs args)
+        private void HandleNewPerformanceData(object? sender, PerformanceDataEventArgs args)
         {
             Debug.WriteLine($"{args.Value} {args.Unit}");
         }

--- a/src/Semoda/Semoda/ViewModels/MainWindowViewModel.cs
+++ b/src/Semoda/Semoda/ViewModels/MainWindowViewModel.cs
@@ -1,9 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.Extensions.DependencyInjection;
 using Semoda.Assets.Languages;
 using Semoda.Models;
-using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 

--- a/src/Semoda/Semoda/Views/Pages/DashboardPage.axaml
+++ b/src/Semoda/Semoda/Views/Pages/DashboardPage.axaml
@@ -36,7 +36,7 @@
 										   Grid.Row="2"
 										   Grid.ColumnSpan="2"/>
 			<ctr:DashboardElementContainer Grid.Column="0"
-										   Grid.Row="4"/>
+										   Grid.Row="3"/>
 			<ctr:DashboardElementContainer Grid.Column="1"
 										   Grid.Row="3"
 										   Grid.ColumnSpan="2"/>


### PR DESCRIPTION
Handles Issue #14 
Adds support of CPU-Utilization tracking and RAM-Usage. 
The other performance indicator are postponed to a later time. 
Inside of the DashboardPageViewModel is an example how to register for the events, which hold the informations about the performance indicators. 
The solution is already aware of different plattforms. Currently only Windows is supported.
